### PR TITLE
Fix: Update CSP and X-Frame-Options for Google AdSense compatibility

### DIFF
--- a/ocr-web/public/.htaccess
+++ b/ocr-web/public/.htaccess
@@ -10,22 +10,33 @@ RewriteRule ^(.*)$ /index.html [QSA,L]
 <IfModule mod_headers.c>
     # HSTS (HTTP Strict Transport Security)
     Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
-    
-    # Content Security Policy
-    Header always set Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://pagead2.googlesyndication.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://www.google-analytics.com https://pagead2.googlesyndication.com https://googleads.g.doubleclick.net; frame-src 'self' https://googleads.g.doubleclick.net https://tpc.googlesyndication.com; object-src 'none'; base-uri 'self'; form-action 'self';"
-    
+
+    # Content Security Policy - updated for AdSense compatibility
+    Header always set Content-Security-Policy "
+    default-src 'self'; 
+    script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://pagead2.googlesyndication.com https://googleads.g.doubleclick.net https://tpc.googlesyndication.com https://static.cloudflareinsights.com; 
+    style-src 'self' 'unsafe-inline'; 
+    img-src 'self' data: https:; 
+    font-src 'self' data:; 
+    connect-src 'self' https://www.google-analytics.com https://pagead2.googlesyndication.com https://googleads.g.doubleclick.net https://ep1.adtrafficquality.google https://cloudflareinsights.com; 
+    frame-src 'self' https://googleads.g.doubleclick.net https://pagead2.googlesyndication.com https://tpc.googlesyndication.com; 
+    fenced-frame-src 'self' https://googleads.g.doubleclick.net https://pagead2.googlesyndication.com https://tpc.googlesyndication.com; 
+    object-src 'none'; 
+    base-uri 'self'; 
+    form-action 'self';"
+
     # X-Content-Type-Options
     Header always set X-Content-Type-Options "nosniff"
-    
-    # X-Frame-Options
-    Header always set X-Frame-Options "DENY"
-    
+
+    # X-Frame-Options - changed from DENY to SAMEORIGIN to support AdSense
+    Header always set X-Frame-Options "SAMEORIGIN"
+
     # X-XSS-Protection
     Header always set X-XSS-Protection "1; mode=block"
-    
+
     # Referrer Policy
     Header always set Referrer-Policy "strict-origin-when-cross-origin"
-    
+
     # Remove server signature
     Header unset Server
     Header unset X-Powered-By
@@ -65,4 +76,4 @@ RewriteRule ^(.*)$ /index.html [QSA,L]
 <Files "*.log">
     Order allow,deny
     Deny from all
-</Files> 
+</Files>


### PR DESCRIPTION
- Updated Content Security Policy to allow Google Ads and Cloudflare domains
- Added 'unsafe-eval' to script-src for proper AdSense functionality
- Changed X-Frame-Options from DENY to SAMEORIGIN to support ad iframes
- Added comprehensive domain coverage for frame-src, fenced-frame-src, and connect-src
- Improved CSP formatting for better maintainability
- Resolves browser console CSP errors for ad integration and analytics